### PR TITLE
Fix Transport class import.

### DIFF
--- a/slackHook.d.ts
+++ b/slackHook.d.ts
@@ -1,4 +1,4 @@
-import as Transport from "winston-transport";
+import Transport = require("winston-transport");
 
 declare class SlackHook extends Transport {
     constructor (opts: SlackHook.SlackHookOptions);

--- a/slackHook.d.ts
+++ b/slackHook.d.ts
@@ -1,4 +1,4 @@
-import * as Transport from "winston-transport";
+import as Transport from "winston-transport";
 
 declare class SlackHook extends Transport {
     constructor (opts: SlackHook.SlackHookOptions);


### PR DESCRIPTION
Using asterisk-style import causes 'Type 'typeof TransportStream' is not a constructor function type.' TS error.