### PR TITLE
Added posibility to filter out messages

### DIFF
--- a/__tests__/slackHook.spec.js
+++ b/__tests__/slackHook.spec.js
@@ -1,50 +1,158 @@
 import mockAxios from "../__mocks__/axios";
 import SlackHook from "../slackHook";
 
-const fakeOpts = {
-    name: 'totally-fake-slackhook',
-    formatter: 'totally-fake-formatter',
-    webhookUrl: 'https://totally.fake.url',
-    unfurlLinks: true,
-    unfurlMedia: true,
-    mrkdwn: true
-};
-
-let fakeSlackHook;
-
-beforeAll(() => {
-    fakeSlackHook = new SlackHook(fakeOpts);
-});
-
-beforeEach(() => {
-    jest.resetModules();
-})
-
-it("checks if parameters are correct", () => {
-    expect(fakeSlackHook).toBeInstanceOf(SlackHook);
-    expect(fakeSlackHook.name).toEqual(fakeOpts.name);
-    expect(fakeSlackHook.formatter).toEqual(fakeOpts.formatter);
-    expect(fakeSlackHook.webhookUrl).toEqual(fakeOpts.webhookUrl);
-    expect(fakeSlackHook.unfurlLinks).toEqual(fakeOpts.unfurlLinks);
-    expect(fakeSlackHook.unfurlMedia).toEqual(fakeOpts.unfurlMedia);
-    expect(fakeSlackHook.mrkdwn).toEqual(fakeOpts.mrkdwn);
-    expect(mockAxios.create).toHaveBeenCalledTimes(1);
-});
-
-it("log function gets called with correct params", () => {
-    const fakeCb = jest.fn();
-    const fakePayload = {
-        unfurl_links: fakeOpts.unfurlLinks,
-        unfurl_media: fakeOpts.unfurlMedia,
-        mrkdwn: fakeOpts.mrkdwn,
-        text: 'undefined: undefined'
+describe ("Standard options", () => {
+    const fakeOpts = {
+        name: 'totally-fake-slackhook',
+        formatter: 'totally-fake-formatter',
+        webhookUrl: 'https://totally.fake.url',
+        unfurlLinks: true,
+        unfurlMedia: true,
+        mrkdwn: true
     };
 
-    fakeSlackHook.log({}, fakeCb);
+    let fakeSlackHook;
 
-    expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledTimes(1);
-    expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledWith(
-        fakeOpts.webhookUrl,
-        fakePayload
-    );
+    beforeAll(() => {
+        jest.clearAllMocks();
+        fakeSlackHook = new SlackHook(fakeOpts);
+    });
+
+    beforeEach(() => {
+        jest.resetModules();
+    })
+
+    it("checks if parameters are correct", () => {
+        expect(fakeSlackHook).toBeInstanceOf(SlackHook);
+        expect(fakeSlackHook.name).toEqual(fakeOpts.name);
+        expect(fakeSlackHook.formatter).toEqual(fakeOpts.formatter);
+        expect(fakeSlackHook.webhookUrl).toEqual(fakeOpts.webhookUrl);
+        expect(fakeSlackHook.unfurlLinks).toEqual(fakeOpts.unfurlLinks);
+        expect(fakeSlackHook.unfurlMedia).toEqual(fakeOpts.unfurlMedia);
+        expect(fakeSlackHook.mrkdwn).toEqual(fakeOpts.mrkdwn);
+        expect(mockAxios.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("log function gets called with correct params", () => {
+        const fakeCb = jest.fn();
+        const fakePayload = {
+            unfurl_links: fakeOpts.unfurlLinks,
+            unfurl_media: fakeOpts.unfurlMedia,
+            mrkdwn: fakeOpts.mrkdwn,
+            text: 'undefined: undefined'
+        };
+
+        fakeSlackHook.log({}, fakeCb);
+
+        expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledTimes(1);
+        expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledWith(
+            fakeOpts.webhookUrl,
+            fakePayload
+        );
+    })
+})
+
+describe ("Standard options with custom formatter", () => {
+    const fakeFormatter = jest.fn((info) => ({ text: `Custom message: ${info.message}` }));
+    const fakeOpts = {
+        name: 'totally-fake-slackhook',
+        formatter: fakeFormatter,
+        webhookUrl: 'https://totally.fake.url',
+        unfurlLinks: true,
+        unfurlMedia: true,
+        mrkdwn: true
+    };
+
+    let fakeSlackHook;
+
+    beforeAll(() => {
+        jest.clearAllMocks();
+        fakeSlackHook = new SlackHook(fakeOpts);
+    });
+
+    beforeEach(() => {
+        jest.resetModules();
+    })
+
+    it("checks if parameters are correct", () => {
+        expect(fakeSlackHook).toBeInstanceOf(SlackHook);
+        expect(fakeSlackHook.name).toEqual(fakeOpts.name);
+        expect(fakeSlackHook.formatter).toEqual(fakeOpts.formatter);
+        expect(fakeSlackHook.webhookUrl).toEqual(fakeOpts.webhookUrl);
+        expect(fakeSlackHook.unfurlLinks).toEqual(fakeOpts.unfurlLinks);
+        expect(fakeSlackHook.unfurlMedia).toEqual(fakeOpts.unfurlMedia);
+        expect(fakeSlackHook.mrkdwn).toEqual(fakeOpts.mrkdwn);
+        expect(mockAxios.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("log function gets called with correct params", () => {
+        const fakeCb = jest.fn();
+        const fakePayload = {
+            attachments: undefined,
+            unfurl_links: fakeOpts.unfurlLinks,
+            unfurl_media: fakeOpts.unfurlMedia,
+            mrkdwn: fakeOpts.mrkdwn,
+            text: 'Custom message: undefined'
+        };
+
+        fakeSlackHook.log({}, fakeCb);
+
+        expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledTimes(1);
+        expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledWith(
+            fakeOpts.webhookUrl,
+            fakePayload
+        );
+
+        expect(fakeFormatter).toHaveBeenCalledTimes(1);
+    })
+})
+
+describe ("Standard options with formatter that filters out all messages", () => {
+    const fakeFormatter = jest.fn((info) => false);
+    const fakeOpts = {
+        name: 'totally-fake-slackhook',
+        formatter: fakeFormatter,
+        webhookUrl: 'https://totally.fake.url',
+        unfurlLinks: true,
+        unfurlMedia: true,
+        mrkdwn: true
+    };
+
+    let fakeSlackHook;
+
+    beforeAll(() => {
+        jest.clearAllMocks();
+        fakeSlackHook = new SlackHook(fakeOpts);
+    });
+
+    beforeEach(() => {
+        jest.resetModules();
+    })
+
+    it("checks if parameters are correct", () => {
+        expect(fakeSlackHook).toBeInstanceOf(SlackHook);
+        expect(fakeSlackHook.name).toEqual(fakeOpts.name);
+        expect(fakeSlackHook.formatter).toEqual(fakeOpts.formatter);
+        expect(fakeSlackHook.webhookUrl).toEqual(fakeOpts.webhookUrl);
+        expect(fakeSlackHook.unfurlLinks).toEqual(fakeOpts.unfurlLinks);
+        expect(fakeSlackHook.unfurlMedia).toEqual(fakeOpts.unfurlMedia);
+        expect(fakeSlackHook.mrkdwn).toEqual(fakeOpts.mrkdwn);
+        expect(mockAxios.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("log function gets called with correct params", () => {
+        const fakeCb = jest.fn();
+        const fakePayload = {
+            unfurl_links: fakeOpts.unfurlLinks,
+            unfurl_media: fakeOpts.unfurlMedia,
+            mrkdwn: fakeOpts.mrkdwn,
+            text: 'undefined: undefined'
+        };
+
+        fakeSlackHook.log({}, fakeCb);
+
+        expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledTimes(0);
+
+        expect(fakeFormatter).toHaveBeenCalledTimes(1);
+    })
 })

--- a/slackHook.d.ts
+++ b/slackHook.d.ts
@@ -5,6 +5,18 @@ declare class SlackHook extends Transport {
 }
 
 declare namespace SlackHook {
+    interface TransformableInfo {
+        level: string;
+        message: string;
+        [key: string]: any;
+    }
+
+    interface SlackMessage {
+        text?: string
+        attachments?: any[]
+        blocks?: any[]
+    }
+
     interface SlackHookOptions {
         /**
          * Slack incoming webhook URL. 
@@ -16,11 +28,7 @@ declare namespace SlackHook {
         /**
          * Custom function to format messages with. This function accepts the `info` object ({@link https://github.com/winstonjs/winston/blob/master/README.md#streams-objectmode-and-info-objects see Winston documentation}) and must return an object with at least one of the following three keys: `text` (string), `attachments` (array of {@link https://api.slack.com/messaging/composing/layouts#attachments attachment objects}), `blocks` (array of {@link https://api.slack.com/messaging/composing/layouts#adding-blocks layout block objects}). These will be used to structure the format of the logged Slack message. By default, messages will use the format of `[level]: [message]` with no attachments or layout blocks.
          */
-        formatter?: (info: {
-            level: string,
-            message: string,
-            [key: string]: any
-        }) => any;
+        formatter?: (info: TransformableInfo) => SlackMessage | false;
         /**
          * Level to log. Global settings will apply if left undefined.
          */

--- a/slackHook.js
+++ b/slackHook.js
@@ -32,6 +32,8 @@ module.exports = class SlackHook extends Transport {
     if (this.formatter && typeof this.formatter === 'function') {
       let layout = this.formatter(info);
 
+      if (!layout) return;
+
       // Note: Supplying `text` when `blocks` is also supplied will cause `text` 
       // to be used as a fallback for clients/surfaces that don't suopport blocks
       payload.text = layout.text || undefined;


### PR DESCRIPTION
I encountered the same casuistry requested in #12 so I suggest a custom solution. The following functionalities have been added:
- SlackHookOptions formatter can return false to filter out messages
- SlackHookOptions formatter types updated
- New test configuring SlackHook with a custom formatter that changes the output
- New test configuring SlackHook with a custom formatter that filters out the message