### PR TITLE
feat: Add ability to specify custom webhook parameters

### DIFF
--- a/__tests__/slackHook.spec.js
+++ b/__tests__/slackHook.spec.js
@@ -107,6 +107,54 @@ describe ("Standard options with custom formatter", () => {
     })
 })
 
+describe ("Custom options with custom formatter", () => {
+    const fakeFormatter = jest.fn((info) => ({ text: `Custom message: ${info.message}`, icon_url: "a", username: "b", icon_emoji: "c", channel:"d"  }));
+    const fakeOpts = {
+        name: 'totally-fake-slackhook',
+        formatter: fakeFormatter,
+        webhookUrl: 'https://totally.fake.url',
+        unfurlLinks: true,
+        unfurlMedia: true,
+        mrkdwn: true
+    };
+
+    let fakeSlackHook;
+
+    beforeAll(() => {
+        jest.clearAllMocks();
+        fakeSlackHook = new SlackHook(fakeOpts);
+    });
+
+    beforeEach(() => {
+        jest.resetModules();
+    })
+    
+    it("log function gets called with correct params", () => {
+        const fakeCb = jest.fn();
+        const fakePayload = {
+            attachments: undefined,
+            unfurl_links: fakeOpts.unfurlLinks,
+            unfurl_media: fakeOpts.unfurlMedia,
+            mrkdwn: fakeOpts.mrkdwn,
+            text: 'Custom message: undefined',
+            icon_url: "a", 
+            username: "b", 
+            icon_emoji: "c", 
+            channel:"d"  
+        };
+
+        fakeSlackHook.log({}, fakeCb);
+
+        expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledTimes(1);
+        expect(fakeSlackHook.axiosInstance.post).toHaveBeenCalledWith(
+            fakeOpts.webhookUrl,
+            fakePayload
+        );
+
+        expect(fakeFormatter).toHaveBeenCalledTimes(1);
+    })
+})
+
 describe ("Standard options with formatter that filters out all messages", () => {
     const fakeFormatter = jest.fn((info) => false);
     const fakeOpts = {

--- a/slackHook.d.ts
+++ b/slackHook.d.ts
@@ -15,6 +15,10 @@ declare namespace SlackHook {
         text?: string
         attachments?: any[]
         blocks?: any[]
+        icon_emoji?: string
+        username?: string
+        icon_url?: string
+        channel?: string
     }
 
     interface SlackHookOptions {

--- a/slackHook.js
+++ b/slackHook.js
@@ -35,10 +35,10 @@ module.exports = class SlackHook extends Transport {
       if (!layout) return;
 
       // Note: Supplying `text` when `blocks` is also supplied will cause `text` 
-      // to be used as a fallback for clients/surfaces that don't suopport blocks
-      payload.text = layout.text || undefined;
-      payload.attachments = layout.attachments || undefined;
-      payload.blocks = layout.blocks || undefined;
+      // to be used as a fallback for clients/surfaces that don't suopport blocks   
+      Object.keys(layout).forEach(key => {
+        payload[key] = layout[key];
+      });
     } else {
       payload.text = `${info.level}: ${info.message}`
     }


### PR DESCRIPTION
It would be great to add support for these custom webhook parameters, since this is still using the legacy integration.
If you'd prefer me to use the more explicit parameter mapping let me know, happy to refactor.

https://api.slack.com/legacy/custom-integrations/messaging/webhooks#legacy-customizations