### PR TITLE
Update type definition for SlackHookOptions

### DIFF
--- a/slackHook.d.ts
+++ b/slackHook.d.ts
@@ -21,7 +21,7 @@ declare namespace SlackHook {
         channel?: string;
     }
 
-    interface SlackHookOptions {
+    interface SlackHookOptions extends TransportStreamOptions {
         /**
          * Slack incoming webhook URL.
          *


### PR DESCRIPTION
Options are passed to the parent `Transport` class (named `TransportStream` in  the `winston-transport` package) via `super(opts)` in the constructor, so those properties should also be exposed when initializing SlackHook.

Those properties are:

```typescript
format?: logform.Format;
level?: string;
silent?: boolean;
handleExceptions?: boolean;
handleRejections?: boolean;
```

In my case, I needed this personally to access the `format` key to use `winston.format.timestamp()` and `winston.format.metadata()`.