### PR TITLE
Fix missing type

### DIFF
--- a/slackHook.d.ts
+++ b/slackHook.d.ts
@@ -21,7 +21,7 @@ declare namespace SlackHook {
         channel?: string;
     }
 
-    interface SlackHookOptions extends TransportStreamOptions {
+    interface SlackHookOptions extends Transport.TransportStreamOptions {
         /**
          * Slack incoming webhook URL.
          *


### PR DESCRIPTION
Sorry, I forgot to "import" the type I was extending

Had that change locally, but not committed 🤦 

To be clear, https://github.com/TheAppleFreak/winston-slack-webhook-transport/pull/26 didn't break anything, as far as I can tell, but it also didn't fix what it was supposed to fix.